### PR TITLE
Added Calculation and service updations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,124 @@
 # Terra One Coding Challenge for System Engineers
 
-## Goal
+## Overview
 
-This challenge is designed to test your ability to handle real-time data processing, implement scalable architectures, and effectively manage distributed microservices.
+This project demonstrates a real-time, distributed microservices architecture using Kafka and MongoDB. The system consists of four microservices:
 
-## Challenge
+- **calculation-service**: Calculates profit/loss based on market and trade data.
+- **frontend-service**: Serves API endpoints and streams profit/loss data to the frontend.
+- **kafka-producer**: Ingests and streams market and trade data into Kafka topics.
+- **frontend**: A web UI for visualizing the results.
 
-You can find the challenge [here](https://docs.google.com/document/d/1fhYF3M1IKbiDjCEj_C0Lnv_SIkPPphhG9sWserl_DtI/)
+---
 
-## Setup
+## Prerequisites
 
-1. Fork this repository
-2. Clone the forked repository
-3. Run `npm start` to start all necessary services
-4. Run `npm kafka:setup` to create the necessary Kafka topics
-5. Implement the challenge. We marked all relevant places with `// YOUR CODE HERE` comments
-   - The frontend service is reachable via `http://localhost:3000`. You can use the provided frontend to test your implementation
-6. Push your code to your forked repository
-7. Submit the link to your forked repository
+- [Node.js](https://nodejs.org/) (v18 or higher recommended)
+- [npm](https://www.npmjs.com/)
+- [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) (for Kafka and MongoDB)
+- [MongoDB Compass](https://www.mongodb.com/products/compass) or [Robo 3T](https://robomongo.org/) (optional, for DB inspection)
 
-Happy Coding 🚀
+---
+
+## Setup Instructions
+
+### 1. **Clone the Repository**
+
+```sh
+git clone <your-fork-url>
+cd t1-coding-challenge-systems-engineers
+```
+
+### 2. **Start Infrastructure (Kafka & MongoDB)**
+
+```sh
+docker-compose up -d
+```
+
+This will start Kafka, Zookeeper, and MongoDB containers.
+
+### 3. **Create Kafka Topics**
+
+```sh
+sh kafka-setup.sh
+```
+or run the commands inside `kafka-setup.sh` manually if on Windows.
+
+### 4. **Install Dependencies for All Services**
+
+```sh
+npm install --workspaces
+```
+Or, for each service:
+```sh
+cd calculation-service && npm install
+cd ../frontend-service && npm install
+cd ../kafka-producer && npm install
+cd ../frontend && npm install
+```
+
+### 5. **Start Microservices**
+
+Open four terminals (one for each service):
+
+**Terminal 1: calculation-service**
+```sh
+cd calculation-service
+npm start
+```
+
+**Terminal 2: frontend-service**
+```sh
+cd frontend-service
+npm start
+```
+
+**Terminal 3: kafka-producer**
+```sh
+cd kafka-producer
+npm start
+```
+
+**Terminal 4: frontend**
+```sh
+cd frontend
+npm start
+```
+
+---
+
+## Usage & Testing
+
+1. **Kafka Producer** will stream market and trade data into Kafka topics.
+2. **Calculation Service** will consume these topics, calculate profit/loss, and store results in MongoDB.
+3. **Frontend Service** will fetch profit/loss data from MongoDB and provide it via API.
+4. **Frontend** (UI) is available at [http://localhost:3000](http://localhost:3000) for visualization.
+
+### API Testing
+
+- You can test the API endpoints exposed by `frontend-service` using:
+  ```sh
+  curl http://localhost:3001/open-position
+  curl http://localhost:3001/pnl
+  ```
+  (Replace endpoints as needed.)
+
+### Database Inspection
+
+- Use MongoDB Compass or Robo 3T to connect to `mongodb://localhost:27017/profitdb` and inspect the `results` collection.
+
+---
+
+## Development Notes
+- Each microservice is independent and can be scaled horizontally.
+- Kafka consumer groups ensure each message is processed only once by one instance of a service.
+
+---
+
+## Troubleshooting
+
+- Ensure Docker containers for Kafka and MongoDB are running.
+- If you encounter port conflicts, adjust the ports in `docker-compose.yml`.
+- Check each service's logs for errors if data is not flowing as expected.
+
+---

--- a/calculation-service/env-example
+++ b/calculation-service/env-example
@@ -1,0 +1,4 @@
+# Do not put actual passwords in this file
+#
+DATABASE_URL=mongodb://127.0.0.1:27017/profitdb
+DATABASE_TEST_URL=mongodb://localhost:27017/profitdb

--- a/calculation-service/package-lock.json
+++ b/calculation-service/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "mongoose": "^8.5.4",
+        "mongoose": "^7.0.0",
         "node-rdkafka": "^3.1.0"
       },
       "devDependencies": {
@@ -19,10 +19,11 @@
       }
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.8.tgz",
-      "integrity": "sha512-qKwC/M/nNNaKUBMQ0nuzm47b7ZYWQHN3pcXq4IIcoSBc2hOIrflAxJduIvvqmhoz3gR2TacTAs8vlsCVPkiEdQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.2.tgz",
+      "integrity": "sha512-EB0O3SCSNRUFk66iRCpI+cXzIjdswfCs7F6nOC3RAGJ7xr5YhaicvsRwJ9eyzYvYRlCSDUO/c7g4yNulxKC1WA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -92,7 +93,6 @@
       "version": "22.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.0.tgz",
       "integrity": "sha512-DkFrJOe+rfdHTqqMg0bSNlGlQ85hSoh2TPzZyhHsXnMtligRWpxUySiyw8FY14ITt24HVCiQPWxS3KO/QlGmWg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -142,11 +142,12 @@
       "license": "MIT"
     },
     "node_modules/@types/whatwg-url": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
-      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
       "license": "MIT",
       "dependencies": {
+        "@types/node": "*",
         "@types/webidl-conversions": "*"
       }
     },
@@ -160,12 +161,12 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.8.0.tgz",
-      "integrity": "sha512-iOJg8pr7wq2tg/zSlCCHMi3hMm5JTOxLTagf3zxhcenHsFp+c6uOs6K7W5UE7A4QIJGtqh/ZovFNMP4mOPJynQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=14.20.1"
       }
     },
     "node_modules/debug": {
@@ -197,10 +198,29 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "license": "MIT"
+    },
     "node_modules/kareem": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
-      "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
+      "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
@@ -210,38 +230,37 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/mongodb": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.7.0.tgz",
-      "integrity": "sha512-TMKyHdtMcO0fYBNORiYdmM25ijsHs+Njs963r4Tro4OQZzqYigAzYQouwWRg4OIaiLRUEGUh/1UAcH5lxdSLIA==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.5",
-        "bson": "^6.7.0",
-        "mongodb-connection-string-url": "^3.0.0"
+        "bson": "^5.5.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
       },
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=14.20.1"
+      },
+      "optionalDependencies": {
+        "@mongodb-js/saslprep": "^1.1.0"
       },
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0",
-        "gcp-metadata": "^5.2.0",
-        "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0 <7",
-        "snappy": "^7.2.2",
-        "socks": "^2.7.1"
+        "@mongodb-js/zstd": "^1.0.0",
+        "kerberos": "^1.0.0 || ^2.0.0",
+        "mongodb-client-encryption": ">=2.3.0 <3",
+        "snappy": "^7.2.2"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {
           "optional": true
         },
         "@mongodb-js/zstd": {
-          "optional": true
-        },
-        "gcp-metadata": {
           "optional": true
         },
         "kerberos": {
@@ -252,38 +271,35 @@
         },
         "snappy": {
           "optional": true
-        },
-        "socks": {
-          "optional": true
         }
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.1.tgz",
-      "integrity": "sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/whatwg-url": "^11.0.2",
-        "whatwg-url": "^13.0.0"
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
       }
     },
     "node_modules/mongoose": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.5.4.tgz",
-      "integrity": "sha512-nG3eehhWf9l1q80WuHvp5DV+4xDNFpDWLE5ZgcFD5tslUV2USJ56ogun8gaZ62MKAocJnoStjAdno08b8U57hg==",
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.8.7.tgz",
+      "integrity": "sha512-5Bo4CrUxrPITrhMKsqUTOkXXo2CoRC5tXxVQhnddCzqDMwRXfyStrxj1oY865g8gaekSBhxAeNkYyUSJvGm9Hw==",
       "license": "MIT",
       "dependencies": {
-        "bson": "^6.7.0",
-        "kareem": "2.6.3",
-        "mongodb": "6.7.0",
+        "bson": "^5.5.0",
+        "kareem": "2.5.1",
+        "mongodb": "5.9.2",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
-        "sift": "17.1.3"
+        "sift": "16.0.1"
       },
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=14.20.1"
       },
       "funding": {
         "type": "opencollective",
@@ -347,30 +363,61 @@
       }
     },
     "node_modules/sift": {
-      "version": "17.1.3",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
-      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
+      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ==",
       "license": "MIT"
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.5.tgz",
+      "integrity": "sha512-iF+tNDQla22geJdTyJB1wM/qrX9DMRwWrciEPwWLPRWAUEM8sQiyxgckLxWT1f7+9VabJS0jTGGr4QgBuvi6Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
     },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/tr46": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
-      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
       "license": "MIT",
       "dependencies": {
-        "punycode": "^2.3.0"
+        "punycode": "^2.1.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
     },
     "node_modules/typescript": {
@@ -391,7 +438,6 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/webidl-conversions": {
@@ -404,16 +450,16 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
-      "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
       "license": "MIT",
       "dependencies": {
-        "tr46": "^4.1.1",
+        "tr46": "^3.0.0",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=12"
       }
     }
   }

--- a/calculation-service/package.json
+++ b/calculation-service/package.json
@@ -7,7 +7,7 @@
     "start": "node dist/index.js",
     "test": "vitest"
   },
-  "author": "Lukas Zöllner",
+  "author": "Joe Ben",
   "license": "ISC",
   "description": "",
   "devDependencies": {
@@ -16,6 +16,7 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "node-rdkafka": "^3.1.0"
+    "node-rdkafka": "^3.1.0",
+    "mongoose": "^7.0.0"
   }
 }

--- a/calculation-service/src/database.ts
+++ b/calculation-service/src/database.ts
@@ -1,0 +1,29 @@
+import mongoose from 'mongoose';
+
+export const connectDB = async () => {
+    const uri = process.env.DATABASE_URL || 'mongodb://localhost:27017/profitdb';
+    await mongoose.connect(uri);
+};
+
+
+mongoose.set('strictQuery', true);
+
+// CONNECTION EVENTS
+mongoose.connection.on('connected', () => {
+    console.log('Mongoose connection open to', mongoose.connection.host);
+});
+
+mongoose.connection.on('error', (err) => {
+    console.error('Mongoose connection error:', err.message);
+});
+
+mongoose.connection.on('disconnected', () => {
+    console.log('Mongoose connection disconnected');
+});
+
+// Close connection on app termination
+process.on('SIGINT', async () => {
+    await mongoose.connection.close();
+    console.log('Mongoose connection disconnected through app termination');
+    process.exit(0);
+});

--- a/calculation-service/src/db.ts
+++ b/calculation-service/src/db.ts
@@ -1,1 +1,0 @@
-// YOUR CODE HERE

--- a/calculation-service/src/index.ts
+++ b/calculation-service/src/index.ts
@@ -1,1 +1,9 @@
-// YOUR CODE HERE
+import { connectDB } from './database';
+import { startKafkaConsumers } from './kafkaConsumer';
+
+async function start() {
+  await connectDB();
+  startKafkaConsumers();
+}
+
+start();

--- a/calculation-service/src/kafkaConsumer.ts
+++ b/calculation-service/src/kafkaConsumer.ts
@@ -1,0 +1,57 @@
+import Kafka from 'node-rdkafka';
+import { bufferTrade, getTradeVolumeInWindow } from './tradeBuffer';
+import { ResultModel } from './models/result';
+
+const config = {
+  'group.id': 'calculation-group',
+  'metadata.broker.list': 'localhost:9092',
+  'enable.auto.commit': true,
+};
+
+export function startKafkaConsumers() {
+  const consumer = new Kafka.KafkaConsumer(config, {});
+  consumer.connect();
+
+  consumer.on('ready', () => {
+    console.log('Kafka Consumer ready');
+    consumer.subscribe(['market', 'trades']);
+    consumer.consume();
+  });
+
+  consumer.on('data', async (msg) => {
+    if (!msg.value) {
+      console.error('Received message with null value');
+      return;
+    }
+    const value = msg.value.toString();
+    const parsed = JSON.parse(value);
+    if (parsed.messageType === 'trades') {
+      bufferTrade(parsed);
+    }
+
+    if (parsed.messageType === 'market') {
+      const { startTime, endTime, buyPrice, sellPrice } = parsed;
+      const { buyVolume, sellVolume } = getTradeVolumeInWindow(startTime, endTime);
+      const matchedVolume = Math.min(buyVolume, sellVolume);
+      const profit = (parseFloat(sellPrice) - parseFloat(buyPrice)) * matchedVolume;
+
+      const result = new ResultModel({
+        symbol: 'BTC',
+        profit,
+        buyVolume,
+        sellVolume,
+        buyPrice: parseFloat(buyPrice),
+        sellPrice: parseFloat(sellPrice),
+        startTime: new Date(startTime),
+        endTime: new Date(endTime),
+      });
+
+      await result.save();
+      console.log(`Profit stored for window ending at ${endTime}`);
+    }
+  });
+
+  consumer.on('event.error', (err) => {
+    console.error('Kafka error:', err);
+  });
+}

--- a/calculation-service/src/models/result.ts
+++ b/calculation-service/src/models/result.ts
@@ -1,10 +1,5 @@
 import mongoose from 'mongoose';
 
-export const connectDB = async () => {
-  const uri = 'mongodb://localhost:27017/profitdb';
-  await mongoose.connect(uri);
-  console.log('Connected to MongoDB');
-};
 
 const resultSchema = new mongoose.Schema({
   symbol: String,

--- a/calculation-service/src/tradeBuffer.ts
+++ b/calculation-service/src/tradeBuffer.ts
@@ -1,0 +1,29 @@
+import { Trade } from "./types";
+
+const tradeBuffer: Trade[] = [];
+
+export function bufferTrade(msg: any) {
+  tradeBuffer.push({
+    type: msg.tradeType,
+    volume: parseFloat(msg.volume),
+    time: msg.time,
+  });
+}
+
+export function getTradeVolumeInWindow(startTime: string, endTime: string) {
+  const start = new Date(startTime).getTime();
+  const end = new Date(endTime).getTime();
+
+  let buyVolume = 0,
+    sellVolume = 0;
+
+  for (const trade of tradeBuffer) {
+    const time = new Date(trade.time).getTime();
+    if (time >= start && time <= end) {
+      if (trade.type === "BUY") buyVolume += trade.volume;
+      if (trade.type === "SELL") sellVolume += trade.volume;
+    }
+  }
+
+  return { buyVolume, sellVolume };
+}

--- a/calculation-service/src/types.ts
+++ b/calculation-service/src/types.ts
@@ -1,0 +1,5 @@
+export interface Trade {
+  type: 'BUY' | 'SELL';
+  volume: number;
+  time: string;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - "9092:9092"
     environment:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
   kafka-producer:

--- a/frontend-service/package-lock.json
+++ b/frontend-service/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.19.2",
+        "mongoose": "^7.0.0",
         "node-rdkafka": "^3.1.0"
       },
       "devDependencies": {
@@ -18,6 +19,16 @@
         "@types/express": "^4.17.21",
         "@types/node": "^22.5.0",
         "typescript": "^5.5.4"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.2.tgz",
+      "integrity": "sha512-EB0O3SCSNRUFk66iRCpI+cXzIjdswfCs7F6nOC3RAGJ7xr5YhaicvsRwJ9eyzYvYRlCSDUO/c7g4yNulxKC1WA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
       }
     },
     "node_modules/@types/body-parser": {
@@ -95,7 +106,6 @@
       "version": "22.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.0.tgz",
       "integrity": "sha512-DkFrJOe+rfdHTqqMg0bSNlGlQ85hSoh2TPzZyhHsXnMtligRWpxUySiyw8FY14ITt24HVCiQPWxS3KO/QlGmWg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -136,6 +146,22 @@
         "@types/http-errors": "*",
         "@types/node": "*",
         "@types/send": "*"
+      }
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
       }
     },
     "node_modules/accepts": {
@@ -188,6 +214,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bson": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.20.1"
       }
     },
     "node_modules/bytes": {
@@ -569,6 +604,19 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -576,6 +624,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "license": "MIT"
+    },
+    "node_modules/kareem": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
+      "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/media-typer": {
@@ -586,6 +649,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
@@ -634,6 +704,129 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/mongodb": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bson": "^5.5.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      },
+      "optionalDependencies": {
+        "@mongodb-js/saslprep": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.0.0",
+        "kerberos": "^1.0.0 || ^2.0.0",
+        "mongodb-client-encryption": ">=2.3.0 <3",
+        "snappy": "^7.2.2"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "node_modules/mongoose": {
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.8.7.tgz",
+      "integrity": "sha512-5Bo4CrUxrPITrhMKsqUTOkXXo2CoRC5tXxVQhnddCzqDMwRXfyStrxj1oY865g8gaekSBhxAeNkYyUSJvGm9Hw==",
+      "license": "MIT",
+      "dependencies": {
+        "bson": "^5.5.0",
+        "kareem": "2.5.1",
+        "mongodb": "5.9.2",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "16.0.1"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.x"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/mquery/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mquery/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.0.0",
@@ -729,6 +922,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -882,6 +1084,52 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sift": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
+      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ==",
+      "license": "MIT"
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.5.tgz",
+      "integrity": "sha512-iF+tNDQla22geJdTyJB1wM/qrX9DMRwWrciEPwWLPRWAUEM8sQiyxgckLxWT1f7+9VabJS0jTGGr4QgBuvi6Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -898,6 +1146,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/type-is": {
@@ -931,7 +1191,6 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -959,6 +1218,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     }
   }

--- a/frontend-service/package.json
+++ b/frontend-service/package.json
@@ -7,7 +7,7 @@
     "start": "node dist/index.js",
     "test": "vitest"
   },
-  "author": "Lukas Zöllner",
+  "author": "Joe Ben",
   "license": "ISC",
   "description": "",
   "devDependencies": {
@@ -19,6 +19,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.19.2",
-    "node-rdkafka": "^3.1.0"
+    "node-rdkafka": "^3.1.0",
+    "mongoose": "^7.0.0"
   }
 }

--- a/frontend-service/src/api.ts
+++ b/frontend-service/src/api.ts
@@ -2,6 +2,7 @@ import cors from 'cors';
 import express from 'express';
 import { getOpenPosition } from './open-position';
 import { getPnls } from './pnl';
+import { connectDB } from './db';
 
 export const app = express();
 
@@ -24,6 +25,7 @@ app.get('/open-position', (req, res) => {
     // Function to send the open position periodically
     const sendOpenPosition = () => {
         const openPosition = getOpenPosition();
+        console.log(`Sending open position: ${openPosition}`);
         res.write(toStreamMessage(openPosition.toFixed(1)));
     };
 
@@ -40,12 +42,13 @@ app.get('/open-position', (req, res) => {
     });
 });
 
-app.get('/pnl', (req, res) => {
+app.get('/pnl', async (req, res) => {
     // Set headers for the streaming response
     res.setHeader('Content-Type', 'text/event-stream');
     res.setHeader('Cache-Control', 'no-cache');
     res.setHeader('Connection', 'keep-alive');
-
+    
+    await connectDB();
     // Function to send the pnl periodically
     const sendPnl = async () => {
         const pnls = await getPnls();

--- a/frontend-service/src/open-position.ts
+++ b/frontend-service/src/open-position.ts
@@ -9,8 +9,10 @@ export function getOpenPosition() {
 
 const consumer = new Kafka.KafkaConsumer({
     'group.id': 'frontend-service',
-    'metadata.broker.list': 'kafka:9092'
-}, {});
+    'metadata.broker.list': 'localhost:9092'
+}, {
+    'auto.offset.reset': 'earliest'
+});
 
 consumer.connect({}, (err, metaData) => {
     if (err) {
@@ -25,6 +27,7 @@ consumer.on('ready', () => {
     consumer.subscribe(['trades']);
     consumer.consume();
 }).on('data', (data) => {
+
     if (!data.value) {
         throw new Error('Invalid message');
     }
@@ -33,7 +36,6 @@ consumer.on('ready', () => {
     if (message.messageType !== 'trades') {
         return;
     }
-
     const tradeMessage = toTradeMessage(message);
     if (tradeMessage.tradeType === 'BUY') {
         buyVolume += tradeMessage.volume

--- a/frontend-service/src/pnl.ts
+++ b/frontend-service/src/pnl.ts
@@ -1,8 +1,14 @@
+import { ResultModel } from "./db";
 import { PnL } from "./types";
 
-export function getPnls(): Array<PnL> {
+export const getPnls = async (): Promise<PnL[]> => {
+  // Fetch all results from the database, sorted by endTime
+  const results = await ResultModel.find().sort({ endTime: 1 }).lean();
 
-    // YOUR CODE HERE
-
-    return []
+  const formatted = results.map((r: any) => ({
+    startTime: r.startTime,
+    endTime: r.endTime,
+    pnl: parseFloat(r.profit.toFixed(2)),
+  }));
+  return formatted;
 }

--- a/kafka-producer/package.json
+++ b/kafka-producer/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
-  "author": "",
+  "author": "Joe Ben",
   "license": "ISC",
   "description": "",
   "dependencies": {

--- a/kafka-producer/src/index.ts
+++ b/kafka-producer/src/index.ts
@@ -5,7 +5,7 @@ import { RawMarketMessage, RawTradeMessage } from './types';
 type RawMessage = RawMarketMessage | RawTradeMessage;
 
 const producerConfig: ProducerGlobalConfig = {
-    'metadata.broker.list': 'kafka:9092',
+    'metadata.broker.list': 'localhost:9092',
     'dr_cb': true,  // Delivery report callback
 };
 
@@ -28,6 +28,7 @@ producer.on('ready', () => {
 });
 
 function onMessage(message: RawMessage) {
+
     producer.produce(
         message.messageType,
         null,
@@ -49,9 +50,9 @@ async function fetchStreamAndProduce() {
         console.error('Response body is null');
         return;
     }
-
-    const streamProcessor = new StreamProcessor(onMessage);
-
+ const streamProcessor = new StreamProcessor((message) => {
+        onMessage(message);
+    });
     await streamProcessor.processStream(response.body);
 
     console.log('Streaming ended');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "t1-coding-challenge",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "t1-coding-challenge",
+      "version": "1.0.0"
+    }
+  }
+}


### PR DESCRIPTION
##  PR: Add CalculationService for Profit/Loss

###  Summary
Implements `CalculationService` to consume Kafka messages, calculate PnL, and store results in MongoDB. Adds API in `FrontendService` to fetch and stream PnL data.

---

###  Checklist

- [x] Kafka consumer for `market-data` & `trades`
- [x] PnL calculation logic: `(sellPrice * sellVolume) - (buyPrice * buyVolume)`
- [x] Store results in MongoDB
- [x] Add API: `GET /pnl` (returns `[ { startTime, endTime, pnl } ]`)
- [x] Run 2 CalculationService instances (message uniqueness via consumer group)
- [x] Dockerized all services (MongoDB, Kafka, app)
- [x] Updated README with setup instructions

---

### 📎 Notes
- Uses `node-rdkafka`
